### PR TITLE
Endpoint to restart a service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,9 @@ target/
 /models/*.bin
 
 /venv/
+
+# VScode specific
+/.devcontainer
+/.vscode/launch.json
+/.vscode/settings.json
+app/routes.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,12 @@
 {
     "python.defaultInterpreterPath": "./venv/bin/python",
-    "python.formatting.provider": "autopep8",
+    "python.formatting.provider": "none",
     "editor.formatOnSave": true,
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.testing.cwd": "${workspaceFolder}",
     "python.analysis.inlayHints.functionReturnTypes": true,
     "[python]": {
-        "editor.defaultFormatter": "ms-python.autopep8"
+        "editor.defaultFormatter": "ms-python.black-formatter"
     },
 }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -78,3 +78,25 @@ class TestController:
 
         response = self.client.get("/v1/stop-all-services/")
         assert response.status_code == 200
+
+    def test_restart_services(self) -> None:
+        response = self.client.get("/v1/download-service/redis-vector-db")
+        assert response.status_code == 200
+
+        response = self.client.post(
+            "/v1/run-service/",
+            json={"id": "redis-vector-db"},
+        )
+        assert response.status_code == 200
+
+        response = self.client.get("/v1/services/redis-vector-db")
+        assert response.status_code == 200
+
+        response = self.client.post(
+            "/v1/restart-service/",
+            json={"id": "redis-vector-db"},
+        )
+        assert response.status_code == 200
+
+        response = self.client.get("/v1/stop-service/redis-vector-db")
+        assert response.status_code == 200


### PR DESCRIPTION
Adds endpoint to restart a service using the [docker restart method](https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.Container.restart). Solves #84 