### PR TITLE
Append registry after add_services_from_registry()

### DIFF
--- a/app/core/services.py
+++ b/app/core/services.py
@@ -131,8 +131,8 @@ def get_registries():
 
 def add_registry(url: str):
     if url not in utils.REGISTRIES:
-        utils.REGISTRIES.append(url)
         utils.add_services_from_registry(url)
+        utils.REGISTRIES.append(url)
         return url
 
 


### PR DESCRIPTION
It closes #125 
Append registry AFTER `add_services_from_registry` function so that we prevent adding wrong registry url.

It closes #126
If we can't add wrong registries, 126 is not an issue.

Please review @filopedraz @tiero 