### PR TITLE
add CLI-based docker pull

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM python:3.10-slim-bullseye
-
 WORKDIR /usr/src/app/
 
-RUN apt-get update && apt-get install -y gcc
-
-COPY requirements.txt ./
-
-RUN pip install --no-cache-dir -r requirements.txt --upgrade pip
+RUN apt update -qq && apt install -yqq --no-install-recommends \
+    gcc curl \
+    && curl -fsSL https://get.docker.com | sed 's/if is_wsl/if false/' | sh \
+    && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-
 CMD python main.py


### PR DESCRIPTION
- add CLI-based docker pull (it's more reliable than `client.api.pull`)
  + use docker-in-docker
  + use TTY mode & forward signals
    + required to force `docker pull` CLI to print progress
    + might be required for https://github.com/moby/moby/issues/6928
  + use same progress calculation as old version (`client.api.pull`)
  + fallback to old version (`client.api.pull`)

Fixes https://github.com/premAI-io/prem-app/issues/357

btw in future we should probably change from `progress = sum(layers["percentage"]) / len(layers)` to `sum(layers["current"]) / sum(layers["total"])` (related: #79)

## notes

This PR approach (call `docker` binary):

- con: user cannot cancel pull unless they [restart the entire docker daemon](https://stackoverflow.com/questions/29486032/how-to-stop-docker-pull) with `sudo service docker restart` (otherwise, even if they close `prem-app`, the docker daemon will continue pulling in the background - [moby/moby#6928/165481719](https://github.com/moby/moby/issues/6928#issuecomment-165481719) is a lie)
- pro: maybe interrupts work on some other OS? I only tested on Windows & fake Linux (WSL)
- pro: technically it's an upstream (docker) bug, not our problem, and might be fixed in future
- pro: con doesn't seem too bad

alternative approach: tarballs (`curl ghcr.io/.../image.tar | docker load -`, vis. #79):

- con: no layer caching (likely to re-download some existing layers)
- pro: it may be possible to download per-layer tarballs (so can skip existing layers)...
  + con: but that seems a lot of code complexity, effectively reimplementing `docker pull` from scratch.
- pro: there's a basic version here: https://github.com/NotGlop/docker-drag/blob/master/docker_pull.py
  + con: it's 3 years old, currently broken & unmaintained
  + pro: I already have it fixed & working locally
  + pro: can download an `image.tar` over HTTPS (from `ghcr.io` etc) with proper progress
  + con: may break in future if HTTPS API changes
- con: `docker load image.tar && rm image.tar` will have no progress & will take a few sec especially with large images
