### PR TITLE
fix: add dependencies to correctly compile for arm64 platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ WORKDIR /usr/src/app/
 
 RUN apt update -qq && apt install -yqq --no-install-recommends \
     gcc curl \
+    build-essential \
+    libc6-dev \
+    python3-dev \
     && curl -fsSL https://get.docker.com | sed 's/if is_wsl/if false/' | sh \
     && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .


### PR DESCRIPTION
- debug subprocess
- fix: add dependencies to correctly compile for arm64 platforms
