### PR TITLE
Fix DNS response check

### DIFF
--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -262,7 +262,7 @@ def check_dns_exists():
     try:
         response = requests.get(url)
         if response.status_code == HTTPStatus.OK and response.content:
-            if response.headers["Content-Type"] == "application/json":
+            if "application/json" in response.headers["Content-Type"]:
                 json_response = response.json()
                 if json_response is not None and "domain" in json_response:
                     cached_domain = json_response["domain"]


### PR DESCRIPTION
Regression issue introduced by [PR 178](Bugfix in check_dns_exists)

Example response header from dns:
`{'Access-Control-Allow-Headers': 'Content-Type, Authorization', 'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH', 'Access-Control-Allow-Origin': 'http://localhost:1420', 'Content-Type': 'application/json; charset=utf-8', 'Date': 'Tue, 07 Nov 2023 13:58:30 GMT', 'Content-Length': '74'}`

It was failing cause content type is `application/json; charset=utf-8` and not `application/json` as expected.

@tiero @nsosio please review.